### PR TITLE
Make getHeaderParent return real header parent on  Windows 7s win Explorer when there are more items than fits on the screen

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -803,7 +803,11 @@ class ColumnsReview64(ColumnsReview):
 	def getHeaderParent(self):
 		# for imperscrutable reasons, this path gives the header container object
 		# otherwise individually visible as first list children
-		return self.simpleParent.simpleFirstChild.parent
+		headerParent = self.simpleParent.simpleFirstChild
+		if headerParent.parent.role == ct.ROLE_HEADER:
+			return headerParent.parent
+		else:
+			return headerParent.next
 
 	def preCheck(self):
 		# check to ensure shell32 method will work


### PR DESCRIPTION
In Windows Explorer when there are more items than can be displayed on one screen there is a scrollbar near the list of items. On Windows 8 and above it is considered as a decorational only by NVDA's object nav and isn't causing any problems. On windows 7, however it is not, so the code asking about the parent of the first simpleChild starts from this scrollbar and returns the list of files instead of header containing column headers. This PR adds a check which returns proper object on Windows 7.