### PR TITLE
Improvements to Manage Headers dialog

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -1068,40 +1068,32 @@ class HeaderDialog(wx.Dialog):
 		self.headerList = headerList
 		actions = ButtonHelper(wx.VERTICAL)
 		leftClickAction = actions.addButton(self, label=_("Left click"))
-		leftClickAction.Bind(wx.EVT_BUTTON, self.onLeftClick)
+		leftClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "LEFT"))
 		rightClickAction = actions.addButton(self, label=_("Right click"))
-		rightClickAction.Bind(wx.EVT_BUTTON, self.onRightClick)
+		rightClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "RIGHT"))
 		helperSizer.addItem(actions)
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		mainSizer.Add(helperSizer.sizer, border=10, flag=wx.ALL)
 		mainSizer.Fit(self)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onEscape)
 		self.SetSizer(mainSizer)
-		for item in [self.list, leftClickAction, rightClickAction]:
-			item.Bind(wx.EVT_KEY_UP, self.onEscape)
 
-	def onLeftClick(self, event):
+	def onButtonClick(self, event, mouseButton):
 		index = self.list.GetSelection()
 		headerObj = self.headerList[index]
-		self.Destroy()
-		api.setNavigatorObject(headerObj)
-		commands.script_moveMouseToNavigatorObject(None)
-		winUser.mouse_event(winUser.MOUSEEVENTF_LEFTDOWN,0,0,None,None)
-		winUser.mouse_event(winUser.MOUSEEVENTF_LEFTUP,0,0,None,None)
+		self.Close()
+		(left, top, width, height) = headerObj.location
+		winUser.setCursorPos(left+(width//2), top+(height//2))
+		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}DOWN".format(mouseButton)),0,0,None,None)
+		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}UP".format(mouseButton)),0,0,None,None)
 		ui.message(_("%s header clicked")%headerObj.name)
-
-	def onRightClick(self, event):
-		index = self.list.GetSelection()
-		headerObj = self.headerList[index]
 		self.Destroy()
-		api.setNavigatorObject(headerObj)
-		commands.script_moveMouseToNavigatorObject(None)
-		winUser.mouse_event(winUser.MOUSEEVENTF_RIGHTDOWN,0,0,None,None)
-		winUser.mouse_event(winUser.MOUSEEVENTF_RIGHTUP,0,0,None,None)
-		ui.message(_("%s header clicked")%headerObj.name)
 
 	def onEscape(self, event):
 		if event.GetKeyCode() == wx.WXK_ESCAPE:
 			self.Destroy()
+		else:
+			event.Skip()
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 

--- a/sconstruct
+++ b/sconstruct
@@ -8,6 +8,8 @@ import gettext
 import os
 import os.path
 import zipfile
+import sys
+sys.dont_write_bytecode = True
 
 import buildVars
 
@@ -21,7 +23,7 @@ def md2html(source, dest):
 	}
 	with codecs.open(source, "r", "utf-8") as f:
 		mdText = f.read()
-		for k, v in headerDic.iteritems():
+		for k, v in headerDic.items():
 			mdText = mdText.replace(k, v, 1)
 		htmlText = markdown.markdown(mdText)
 	with codecs.open(dest, "w", "utf-8") as f:
@@ -127,7 +129,11 @@ def generateManifest(source, dest):
 		f.write(manifest)
 
 def generateTranslatedManifest(source, language, out):
-	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	# No ugettext in Python 3.
+	if sys.version_info.major == 2:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	else:
+		_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])
@@ -167,7 +173,7 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars={
-		'gettext_package_bugs_address' : 'nvda-translations@freelists.org',
+		'gettext_package_bugs_address' : 'nvda-translations@groups.io',
 		'gettext_package_name' : buildVars.addon_info['addon_name'],
 		'gettext_package_version' : buildVars.addon_info['addon_version']
 	}
@@ -186,3 +192,4 @@ env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)
 env.Default(addon)
+env.Clean (addon, ['.sconsign.dblite', 'addon/doc/en/'])


### PR DESCRIPTION
In the current state the dialog used to click on columns headers was behaving very unreliably for me. I've observed the following issues:
- Dialog not closing after pressing on one of the buttons - this was caused by not skipping events and being stuck inside `onEscape`
- NVDA freezing when attempting to click something - I believe this was caused by the fact that when the dialog was destroyed rest of the function wasn't finished.


These problems are now fixed. In addition I've reorganized code a bit to avoid some duplication and do not waste resources on iterating when binding `onEscape`. I've also upgraded Sconscript to the latest version included in add-on template - while this is obviously not relevant to the main problem Columns Review was one of the last add-ons to which I sometimes contribute which required Python 2 to build. The Sconscript is backwards compatible with Py 2 so there should be no regressions.