### PR TITLE
allow to perform additional actions on columns

### DIFF
--- a/addon/globalPlugins/columnsReview/Exceptions.py
+++ b/addon/globalPlugins/columnsReview/Exceptions.py
@@ -1,0 +1,11 @@
+# Custom exceptions for the Columns Review add-on
+
+
+class noColumnAtIndex(Exception):
+	"""Raised when column at the specified index does not exist."""
+	pass
+
+
+class columnAtIndexNotVisible(Exception):
+	"""Raised when column at the requested index exists, but is not visible."""
+	pass

--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -8,36 +8,24 @@
 # Many thanks to Robert Hänggi and Abdelkrim Bensaïd
 # for shell code suggestions,
 # to Noelia Ruiz Martínez
-# for original selected items feature, 
+# for original selected items feature,
 # to Cyrille Bougot
 # for suggestions and sysListView32 threading support,
 # and to other users of NVDA mailing lists
 # for feedback and comments
 
-from .msg import message as NVDALocale
 from NVDAObjects.IAccessible import getNVDAObjectFromEvent
 from NVDAObjects.IAccessible.sysListView32 import * #List, ListItem, LVM_GETHEADER
 from NVDAObjects.UIA import UIA # For UIA implementations only, chiefly 64-bit.
 from NVDAObjects.behaviors import RowWithFakeNavigation
-from appModules.explorer import GridTileElement, GridListTileElement # Specific for Start Screen tiles.
 import sayAllHandler
 import sys
-py3 = sys.version.startswith("3")
-if py3:
-	from io import StringIO
-else:
-	from cStringIO import StringIO
 from comtypes.client import CreateObject
 from comtypes.gen.IAccessible2Lib import IAccessible2
-from configobj import *
-from configobj import ConfigObj
 from ctypes.wintypes import LPARAM as LParam
-#from cursorManager import CursorManager
 from globalCommands import commands
-from gui.guiHelper import *
-from logHandler import log
 from oleacc import STATE_SYSTEM_MULTISELECTABLE, SELFLAG_TAKEFOCUS, SELFLAG_TAKESELECTION, SELFLAG_ADDSELECTION
-from scriptHandler import isScriptWaiting, getLastScriptRepeatCount
+from scriptHandler import getLastScriptRepeatCount
 from threading import Thread, Event
 from time import sleep
 from tones import beep
@@ -59,18 +47,20 @@ import ui
 import watchdog
 import winUser
 import wx
-try:
-	from six.moves import range as rangeFunc
-except ImportError:
-	rangeFunc = xrange
-except NameError:
-	rangeFunc = range
 from versionInfo import version_year, version_major
+
+from .actions import ACTIONS, actionFromName, configuredActions, getActionIndexFromName
+from .commonFunc import NVDALocale, rangeFunc
+from . import configSpec
+from .Exceptions import columnAtIndexNotVisible, noColumnAtIndex
+
 # useful to simulate profile switch handling
 nvdaVersion = '.'.join([str(version_year), str(version_major)])
 # rename for code clarity
 SysLV32List = List
 SysLV32Item = ListItem
+py3 = sys.version.startswith("3")
+config.conf.spec["columnsReview"] = configSpec.confspec
 
 addonDir = os.path.join(os.path.dirname(__file__), "..", "..")
 if isinstance(addonDir, bytes):
@@ -143,25 +133,6 @@ def isEmptyList(lstObj):
 # useful in ColumnsReview64 to calculate file size
 getBytePerSector = ctypes.windll.kernel32.GetDiskFreeSpaceW
 
-# init config
-configSpecString = ("""
-[general]
-	readHeader = boolean(default=True)
-	copyHeader = boolean(default=True)
-	announceEmptyList = boolean(default=True)
-[keyboard]
-	useNumpadKeys = boolean(default=False)
-	switchChar = string(default="-")
-[gestures]
-	NVDA = boolean(default=True)
-	control = boolean(default=True)
-	alt = boolean(default=False)
-	shift = boolean(default=False)
-	windows = boolean(default=False)
-""")
-confspec = ConfigObj(StringIO(configSpecString), list_values=False, encoding="UTF-8")
-confspec.newlines = "\r\n"
-config.conf.spec["columnsReview"] = confspec
 
 # (re)load config
 def loadConfig():
@@ -277,6 +248,10 @@ class ColumnsReview(RowWithFakeNavigation):
 		_searchEntries = []
 	else:
 		_lastFindText = ""
+	# Should next presses of the command to read column be executed?
+	shouldExecuteNextPresses = True
+	# Keeps track of how many times the given command has been pressed
+	repeatCount = 0
 
 	def initOverlayClass(self):
 		"""maps the correct gestures"""
@@ -317,11 +292,56 @@ class ColumnsReview(RowWithFakeNavigation):
 			for gesture in getScriptGestures(commands.script_sayAll):
 				self.bindGesture(gesture, "readListItems")
 
-	def script_readColumn(self,gesture):
+	def getColumnData(self, colNumber):
+		"""Returs informations about the column at the index given as  parameter.
+		Raises exceptions if the column at the given index does not exist, or is not visible.
+		On success returns dictionary containing columnContent and columnHeader as keys,
+		and the actual info as values.
+		"""
 		raise NotImplementedError
 
-	# Translators: documentation of script to read columns
-	script_readColumn.__doc__ = _("Returns the header and the content of the list column at the index corresponding to the number pressed")
+	def script_readColumn(self, gesture):
+		# ask for index
+		num = self.getIndex(gesture.mainKeyName.rsplit('+', 1)[-1])
+		repeatCount = getLastScriptRepeatCount()
+		if not repeatCount:
+			self.repeatCount = 0
+			self.lastColumn = num
+			self.shouldExecuteNextPresses = True
+		if not self.shouldExecuteNextPresses:
+			return
+		if num != self.lastColumn:
+			self.lastColumn = num
+			self.repeatCount = 1
+		else:
+			self.repeatCount += 1
+		actionToExecute = configuredActions().get(
+			self.repeatCount,
+			ACTIONS[0].name  # Default dummy action
+		)
+		actionToExecute = actionFromName(actionToExecute)
+		if not actionToExecute.performsAction:
+			return
+		self.shouldExecuteNextPresses = actionToExecute.showLaterActions
+		try:
+			columnData = self.getColumnData(num)
+		except noColumnAtIndex:
+			# Translators: message when digit pressed exceed the columns number
+			ui.message(_("No more columns available"))
+			return
+		except columnAtIndexNotVisible:
+			# Translators: Announced when the column at the requested index is not visible.
+			ui.message(_("No more visible columns available"))
+			return
+		columnContent = columnData["columnContent"]
+		columnHeader = columnData["columnHeader"]
+		if columnContent is None and columnHeader is None:
+			return
+		actionToExecute(columnContent, columnHeader)
+	script_readColumn.__doc__ = _(
+		# Translators: documentation of script to read columns
+		"Returns the header and the content of the list column at the index corresponding to the number pressed"
+	)
 
 	def getIndex(self, key):
 		"""get index from key pressed"""
@@ -388,13 +408,8 @@ class ColumnsReview(RowWithFakeNavigation):
 	script_itemInfo.__doc__ = _("Announces list item position information")
 
 	def script_manageHeaders(self, gesture):
-		def run():
-			gui.mainFrame.prePopup()
-			d = HeaderDialog(None, self.appModule.appName, self.getHeaderParent().children)
-			if d:
-				d.Show()
-			gui.mainFrame.postPopup()
-		wx.CallAfter(run)
+		from .dialogs import HeaderDialog
+		wx.CallAfter(HeaderDialog.Run, title=self.appModule.appName, headerList=self.getHeaderParent().children)
 
 	# Translators: documentation for script to manage headers
 	script_manageHeaders.__doc__ = _("Provides a dialog for interactions with list column headers")
@@ -581,44 +596,28 @@ class ColumnsReview32(ColumnsReview):
 	# flag to guarantee thread support
 	THREAD_SUPPORTED = True
 
-	def script_readColumn(self, gesture):
-		# ask for index
-		num = self.getIndex(gesture.mainKeyName.rsplit('+', 1)[-1])
-		if num > self.childCount:
-			# Translators: message when digit pressed exceed the columns number
-			ui.message(_("No more columns available"))
-			return
+	def getColumnData(self, colNumber):
+		if colNumber > self.childCount:
+			raise noColumnAtIndex
 		# for invisible column case
-		num = self.getFixedNum(num)
+		num = self.getFixedNum(colNumber)
 		# getChild is zero-based
-		obj = self.getChild(num-1)
+		obj = self.getChild(num - 1)
 		# None obj should be generated
 		# only in invisible column case
 		if not obj:
-			# Translators: message when digit pressed not match a visible column
-			ui.message(_("No more visible columns available"))
-			return
+			raise columnAtIndexNotVisible
 		# generally, an empty name is a None object,
 		# in Mozilla, instead, it's a unicode object with length 0
 		if obj.name and len(obj.name):
 			# obj.name is the column content
-			content = ''.join([obj.name, ";"])
+			content = obj.name
 		else:
-			# Translators: message when cell in specified column is empty
-			content = _("Not available;")
-		global readHeader, copyHeader
-		if getLastScriptRepeatCount() and self.lastColumn == num:
-			header = ''.join([obj.columnHeaderText, ": "]) if copyHeader else ""
-			if api.copyToClip(header+content):
-				# Translators: message announcing what was copied
-				ui.message(_("Copied in clipboard: %s")%(header+content))
-		else:
-			header = ''.join([obj.columnHeaderText, ": "]) if readHeader else ""
-			self.lastColumn = num
-			ui.message(header+content)
-
-	# Translators: documentation of script to read columns
-	script_readColumn.__doc__ = _("Returns the header and the content of the list column at the index corresponding to the number pressed")
+			content = None
+		header = obj.columnHeaderText
+		if not header or len(header) == 0:
+			header = None
+		return {"columnContent": content, "columnHeader": header}
 
 	def getFixedNum(self, num):
 		child = self.simpleFirstChild
@@ -816,37 +815,25 @@ class ColumnsReview64(ColumnsReview):
 			from NVDAObjects.window import Window
 			return len(Window(self).children)
 
-	def script_readColumn(self,gesture):
-		num = self.getIndex(gesture.mainKeyName.rsplit('+', 1)[-1])
-		# num is passed as is, excluding the first position (0) of the children list
+	def getColumnData(self, colNumber):
+		# colNumber is passed as is, excluding the first position (0) of the children list
 		# containing an icon, so this check in this way
-		if num > self.childCount-1:
-			# Translators: message when digit pressed exceed the columns number
-			ui.message(_("No more columns available"))
-			return
-		obj = self.getChild(num)
+		if colNumber > self.childCount - 1:
+			raise noColumnAtIndex
+		obj = self.getChild(colNumber)
 		# in Windows 7, an empty value is a None object,
 		# in Windows 8, instead, it's a unicode object with length 0
 		if obj and obj.value and len(obj.value):
 			# obj.value is the column content
-			content = ''.join([obj.value, ";"])
+			content = obj.value
 		else:
-			# Translators: message when cell in specified column is empty
-			content = _("Not available;")
-		global readHeader, copyHeader
-		if getLastScriptRepeatCount() and self.lastColumn == num:
-			# obj.name is the column header
-			header = ''.join([self.getChild(num).name, ": "]) if copyHeader else ""
-			if api.copyToClip(header+content):
-				# Translators: message announcing what was copied
-				ui.message(_("Copied in clipboard: %s")%(header+content))
+			content = None
+		# obj.name is the column header
+		if obj and obj.name and len(obj.name):
+			header = obj.name
 		else:
-			header = ''.join([self.getChild(num).name, ": "]) if readHeader else ""
-			self.lastColumn = num
-			ui.message(header+content)
-
-	# Translators: documentation of script to read columns
-	script_readColumn.__doc__ = _("Returns the header and the content of the list column at the index corresponding to the number pressed")
+			header = None
+		return {"columnContent": content, "columnHeader": header}
 
 	def getHeaderParent(self):
 		# for imperscrutable reasons, this path gives the header container object
@@ -1009,15 +996,28 @@ class ColumnsReviewSettingsDialog(superDialogClass):
 
 	# common to dialog and panel
 	def makeSettings(self, settingsSizer):
-		global readHeader, copyHeader, useNumpadKeys, switchChar, announceEmptyList
-		# Translators: label for read-header checkbox in settings
-		self._readHeader = wx.CheckBox(self, label = _("Read the column header"))
-		self._readHeader.SetValue(readHeader)
-		settingsSizer.Add(self._readHeader)
-		# Translators: label for copy-header checkbox in settings
-		self._copyHeader = wx.CheckBox(self, label = _("Copy the column header"))
-		self._copyHeader.SetValue(copyHeader)
-		settingsSizer.Add(self._copyHeader)
+		from .dialogs import configureActionPanel
+		global useNumpadKeys, switchChar, announceEmptyList
+		self.copyCheckboxEnabled = self.readCheckboxEnabled = self.hideNextPanels = False
+		self.panels = []
+		panelsSizer = wx.StaticBoxSizer(
+			wx.StaticBox(
+				self,
+				# Translators: Help message for group of comboboxes allowing to assign action to a keypress.
+				label=_("When pressing combination to read column:")
+			),
+			wx.VERTICAL
+		)
+		for pressNumber, actionName in configuredActions().items():
+			actionIndex = getActionIndexFromName(actionName)
+			panel = configureActionPanel(self, pressNumber, actionIndex)
+			panelsSizer.Add(panel)
+			self.panels.append(panel)
+			if self.hideNextPanels:
+				panel.Disable()
+			if panel.HIDE_NEXT_PANELS_AFTER is not None and actionIndex == panel.HIDE_NEXT_PANELS_AFTER:
+				self.hideNextPanels = True
+		settingsSizer.Add(panelsSizer)
 		keysSizer = wx.StaticBoxSizer(wx.StaticBox(self,
 			# Translators: Help message for sub-sizer of keys choices
 			label=_("Choose the keys you want to use with numbers:")), wx.VERTICAL)
@@ -1051,13 +1051,28 @@ class ColumnsReviewSettingsDialog(superDialogClass):
 
 	# for dialog only
 	def postInit(self):
-		self._readHeader.SetFocus()
+		for panel in self.panels:
+			if panel.IsEnabled():
+				panel.chooseActionCombo.SetFocus()
+				break
 
 	# shared between onOk and onSave
 	def saveConfig(self):
 		# Update Configuration
-		myConf["general"]["readHeader"] = self._readHeader.IsChecked()
-		myConf["general"]["copyHeader"] = self._copyHeader.IsChecked()
+		copyChkFound = readChkFound = False
+		actionsSection = config.conf["columnsReview"]["actions"]
+		for panel in self.panels:
+			if panel.IsEnabled():
+				selectedActionName = ACTIONS[panel.chooseActionCombo.GetSelection()].name
+				actionsSection["press{}".format(panel.panelNumber)] = selectedActionName
+				if not readChkFound and panel.readHeader.IsEnabled():
+					readChkFound = True
+					config.conf["columnsReview"]["general"]["readHeader"] = panel.readHeader.IsChecked()
+				if not copyChkFound and panel.copyHeader.IsEnabled():
+					copyChkFound = True
+					config.conf["columnsReview"]["general"]["copyHeader"] = panel.copyHeader.IsChecked()
+			else:
+				continue
 		myConf["general"]["announceEmptyList"] = self._announceEmptyList.IsChecked()
 		for item in self.keysChks:
 			myConf["gestures"][item[0]] = item[1].IsChecked()
@@ -1084,46 +1099,6 @@ class ColumnsReviewSettingsDialog(superDialogClass):
 			self.settingsSizer.Show(self._switchChar)
 		self.Fit()
 
-class HeaderDialog(wx.Dialog):
-	"""define dialog for column headers management."""
-
-	def __init__(self, parent, appName, headerList):
-		title = ' - '.join([_("Headers manager"), appName])
-		super(HeaderDialog, self).__init__(parent, title=title)
-		helperSizer = BoxSizerHelper(self, wx.HORIZONTAL)
-		visibleHeaders = [x for x in headerList if ct.STATE_INVISIBLE not in x.states]
-		choices = [x.name if x.name else _("Unnamed header") for x in visibleHeaders]
-		self.list = helperSizer.addLabeledControl(_("Headers:"), wx.ListBox, choices=choices)
-		self.list.SetSelection(0)
-		self.headerList = visibleHeaders
-		actions = ButtonHelper(wx.VERTICAL)
-		leftClickAction = actions.addButton(self, label=_("Left click"))
-		leftClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "LEFT"))
-		rightClickAction = actions.addButton(self, label=_("Right click"))
-		rightClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "RIGHT"))
-		helperSizer.addItem(actions)
-		mainSizer = wx.BoxSizer(wx.VERTICAL)
-		mainSizer.Add(helperSizer.sizer, border=10, flag=wx.ALL)
-		mainSizer.Fit(self)
-		self.Bind(wx.EVT_CHAR_HOOK, self.onEscape)
-		self.SetSizer(mainSizer)
-
-	def onButtonClick(self, event, mouseButton):
-		index = self.list.GetSelection()
-		headerObj = self.headerList[index]
-		self.Close()
-		(left, top, width, height) = headerObj.location
-		winUser.setCursorPos(left+(width//2), top+(height//2))
-		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}DOWN".format(mouseButton)),0,0,None,None)
-		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}UP".format(mouseButton)),0,0,None,None)
-		ui.message(_("%s header clicked")%headerObj.name)
-		self.Destroy()
-
-	def onEscape(self, event):
-		if event.GetKeyCode() == wx.WXK_ESCAPE:
-			self.Destroy()
-		else:
-			event.Skip()
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 

--- a/addon/globalPlugins/columnsReview/actions.py
+++ b/addon/globalPlugins/columnsReview/actions.py
@@ -1,0 +1,150 @@
+# Defines actions for the columns Review add-on
+
+import addonHandler
+import api
+import config
+import speech
+import ui
+
+from .commonFunc import rangeFunc
+
+addonHandler.initTranslation()
+
+
+class Action(object):
+	"""Represents an action executed in response to a key press.
+	Objects inheriting from this class can be used as a callable which accepts two params:
+	column content and column header.
+	"""
+
+	name = ""  # Internal name of this action.
+	translatedName = ""  # Description of this action shown to the user in settings dialog.
+	performsAction = False  # Set to True if the given object does something when called.
+	# Set to False if actions assigned to the later key presses
+	# should be  hidden in the settings dialog - useful if the given action moves focus somewhere.
+	showLaterActions = True
+
+	def __call__(self, content, header):
+		raise NotImplementedError
+
+
+class NoAction(Action):
+	"""Dummy action assigned to key presses which shouldn't do anything"""
+
+	name = "noAction"
+	# Translators: Description of the action which simply ignores the pressed key
+	translatedName = _("Do nothing")
+
+
+class ReadAction(Action):
+	"""Read content, and optionally header, of the given column."""
+
+	name = "read"
+	# Translators: Name of the action which reads given column.
+	translatedName = _("Read column")
+	performsAction = True
+
+	def __call__(self, columnContent, columnHeader):
+		if not columnContent:
+			# Translators: Presented for an empty column.
+			columnContent = _("Empty column")
+		if not columnHeader or config.conf["columnsReview"]["general"]["readHeader"] is False:
+			columnHeader = ""
+		else:
+			columnHeader = u"{}: ".format(columnHeader)
+		ui.message(u"{0}{1}".format(columnHeader, columnContent))
+
+
+class CopyAction(Action):
+	"""Copies content, and optionally header, of the given column."""
+
+	name = "copy"
+	# Translators: Name of the action which copies given column.
+	translatedName = _("Copy column")
+	performsAction = True
+
+	def __call__(self, columnContent, columnHeader):
+		if not columnContent:
+			# Translators: Presented for an empty column.
+			columnContent = _("Empty column")
+		if not columnHeader or config.conf["columnsReview"]["general"]["copyHeader"] is False:
+			columnHeader = ""
+		else:
+			columnHeader = u"{}: ".format(columnHeader)
+		res = u"{0}{1}".format(columnHeader, columnContent)
+		if api.copyToClip(res):
+			# Translators: message announcing what was copied
+			ui.message(u"{} copied.".format(res))
+
+
+class SpellAction(Action):
+	"""Spells content of the given column."""
+
+	name = "spell"
+	# Translators: Name of the action which spells given column.
+	translatedName = _("Spell column")
+	performsAction = True
+
+	def __call__(self, columnContent, columnHeader):
+		if not columnContent:
+			# Translators: Presented for an empty column.
+			ui.message(_("Empty column"))
+			return
+		speech.speakSpelling(columnContent)
+
+
+class DisplayAction(Action):
+	"""Displays content of the given column in the browseable message"""
+
+	name = "display"
+	# Translators: Name of the action which displays content of the given column in the browseable message.
+	translatedName = _("Show column content in browse mode")
+	performsAction = True
+	showLaterActions = False  # The list item with focus loses it when browseable message is shown.
+
+	def __call__(self, columnContent, columnHeader):
+		if not columnContent:
+			# Translators: Presented for an empty column.
+			ui.message(_("Empty column"))
+			return
+		if not columnHeader:
+			columnHeader = u""
+		ui.browseableMessage(columnContent, title=columnHeader)
+
+
+# List of actions in order in which they appear in the  GUI
+# when implementing a new one please add it at the end.
+ACTIONS = (
+	NoAction(),
+	ReadAction(),
+	CopyAction(),
+	SpellAction(),
+	DisplayAction()
+)
+
+
+def actionFromName(name):
+	matchingActions = [action for action in ACTIONS if action.name == name]
+	if not matchingActions:
+		raise RuntimeError("Action named %s  does not exist" % (name))
+	if len(matchingActions) > 1:
+		raise RuntimeError(
+			"More than one action with such name exist."
+			"This is unexpected."
+		)
+	return matchingActions[0]
+
+
+def getActionIndexFromName(name):
+	for actionIndex, actionObject in enumerate(ACTIONS):
+		if actionObject.name == name:
+			return actionIndex
+	raise ValueError("Action named %s not in actions list" % name)
+
+
+def configuredActions():
+	pressesToActions = dict()
+	actionsSection = config.conf["columnsReview"]["actions"]
+	for num in rangeFunc(1, len(ACTIONS)):
+		pressesToActions[num] = actionsSection["press{}".format(num)]
+	return pressesToActions

--- a/addon/globalPlugins/columnsReview/commonFunc.py
+++ b/addon/globalPlugins/columnsReview/commonFunc.py
@@ -1,0 +1,17 @@
+# Utility functions for the Columns Review add-on
+
+
+def rangeFunc(*args, **kwargs):
+	try:
+		import six
+		return six.moves.range(*args, **kwargs)
+	except ImportError:
+		try:
+			return __builtins__["xrange"](*args, **kwargs)
+		except TypeError:
+			return range(*args, **kwargs)
+
+
+# We need to store original NVDA gettext function,
+# to be able to take advantage of messages translated in NVDA core.
+NVDALocale = _

--- a/addon/globalPlugins/columnsReview/configSpec.py
+++ b/addon/globalPlugins/columnsReview/configSpec.py
@@ -1,0 +1,34 @@
+# Config specification for the Columns Review add-on
+
+try:
+	from cStringIO import StringIO
+except ModuleNotFoundError:  # Python 3
+	from io import StringIO
+
+from configobj import ConfigObj
+
+from . actions import ACTIONS
+
+
+configSpecString = ("""
+[general]
+	readHeader = boolean(default=True)
+	copyHeader = boolean(default=True)
+	announceEmptyList = boolean(default=True)
+[keyboard]
+	useNumpadKeys = boolean(default=False)
+	switchChar = string(default="-")
+[gestures]
+	NVDA = boolean(default=True)
+	control = boolean(default=True)
+	alt = boolean(default=False)
+	shift = boolean(default=False)
+	windows = boolean(default=False)
+[actions]
+	press1 = option({actionNames} default="read")
+	press2 = option({actionNames} default="copy")
+	press3 = option({actionNames} default="noAction")
+	press4 = option({actionNames} default="noAction")
+""".format(actionNames=''.join('"{}", '.format(action.name) for action in ACTIONS)[:-1]))
+confspec = ConfigObj(StringIO(configSpecString), list_values=False, encoding="UTF-8")
+confspec.newlines = "\r\n"

--- a/addon/globalPlugins/columnsReview/dialogs.py
+++ b/addon/globalPlugins/columnsReview/dialogs.py
@@ -1,0 +1,146 @@
+# GUI dialogs for the Columns Review add-on
+
+import wx
+
+import addonHandler
+import config
+import controlTypes as ct
+import gui
+from gui.guiHelper import BoxSizerHelper, ButtonHelper
+import ui
+import winUser
+
+from .actions import ACTIONS, getActionIndexFromName
+
+addonHandler.initTranslation()
+
+
+class configureActionPanel(wx.Panel):
+
+	COPY_ACTION_INDEX = getActionIndexFromName("copy")
+	READ_ACTION_INDEX = getActionIndexFromName("read")
+	try:
+		HIDE_NEXT_PANELS_AFTER = ACTIONS.index(
+			[action for action in ACTIONS if action.showLaterActions is False][0]
+		)
+	except(IndexError, ValueError):
+		HIDE_NEXT_PANELS_AFTER = None
+
+	ON_PRESS_LABELS = {
+		# Translators: Label of a combobox in which action can be assigned to a first press of the shortcut.
+		1: _("On first press:"),
+		# Translators: Label of a combobox in which action can be assigned to a second press of the shortcut.
+		2: _("On second press:"),
+		# Translators: Label of a combobox in which action can be assigned to a third press of the shortcut.
+		3: _("On third press:"),
+		# Translators: Label of a combobox in which action can be assigned to a fourth press of the shortcut.
+		4: _("On fourth press:")
+	}
+
+	TRANSLATED_ACTION_NAMES = tuple(action.translatedName for action in ACTIONS)
+
+	def __init__(self, parent, panelNumber, initialSelection):
+		self.panelNumber = panelNumber
+		super(configureActionPanel, self).__init__(parent)
+		sizer = BoxSizerHelper(self, orientation=wx.VERTICAL)
+		self.chooseActionCombo = sizer.addLabeledControl(
+			self.ON_PRESS_LABELS[self.panelNumber],
+			wx.Choice,
+			choices=self.TRANSLATED_ACTION_NAMES
+		)
+		self.chooseActionCombo.SetSelection(initialSelection)
+		self.chooseActionCombo.Bind(wx.EVT_CHOICE, self.onSelectedActionChange)
+		# Translators: label for read-header checkbox in settings
+		self.readHeader = wx.CheckBox(self, label=_("Read the column header"))
+		self.readHeader.SetValue(config.conf["columnsReview"]["general"]["readHeader"])
+		sizer.addItem(self.readHeader)
+		# Translators: label for copy-header checkbox in settings
+		self.copyHeader = wx.CheckBox(self, label=_("Copy the column header"))
+		self.copyHeader.SetValue(config.conf["columnsReview"]["general"]["copyHeader"])
+		sizer.addItem(self.copyHeader)
+		self.setControlsVisibility()
+		self.SetSizerAndFit(sizer.sizer)
+
+	def onSelectedActionChange(self, evt):
+		if evt.GetSelection() == self.READ_ACTION_INDEX and not self.Parent.readCheckboxEnabled:
+			self.readHeader.Enable()
+		else:
+			self.readHeader.Disable()
+		self.Parent.readCheckboxEnabled = any([p.readHeader.IsEnabled() for p in self.Parent.panels])
+		if evt.GetSelection() == self.COPY_ACTION_INDEX and not self.Parent.copyCheckboxEnabled:
+			self.copyHeader.Enable()
+		else:
+			self.copyHeader.Disable()
+		self.Parent.copyCheckboxEnabled = any([p.copyHeader.IsEnabled() for p in self.Parent.panels])
+		for panel in self.Parent.panels[self.panelNumber:]:
+			panel.setControlsVisibility()
+		if evt.GetSelection() == self.HIDE_NEXT_PANELS_AFTER:
+			for panel in self.Parent.panels[self.panelNumber:]:
+				panel.Disable()
+		else:
+			for panel in self.Parent.panels[self.panelNumber:]:
+				panel.Enable()
+				if panel.chooseActionCombo.GetSelection() == self.HIDE_NEXT_PANELS_AFTER:
+					break
+		self.Parent.settingsSizer.Fit(self.Parent)
+
+	def setControlsVisibility(self):
+		if self.chooseActionCombo.GetSelection() == self.READ_ACTION_INDEX and not self.Parent.readCheckboxEnabled:
+			self.Parent.readCheckboxEnabled = True
+			self.readHeader.Enable()
+		else:
+			self.readHeader.Disable()
+		if self.chooseActionCombo.GetSelection() == self.COPY_ACTION_INDEX and not self.Parent.copyCheckboxEnabled:
+			self.Parent.copyCheckboxEnabled = True
+			self.copyHeader.Enable()
+		else:
+			self.copyHeader.Disable()
+
+
+class HeaderDialog(wx.Dialog):
+	"""define dialog for column headers management."""
+
+	def __init__(self, title, headerList):
+		super(HeaderDialog, self).__init__(None, title=' - '.join([_("Headers manager"), title]))
+		helperSizer = BoxSizerHelper(self, wx.HORIZONTAL)
+		visibleHeaders = [x for x in headerList if ct.STATE_INVISIBLE not in x.states]
+		choices = [x.name if x.name else _("Unnamed header") for x in visibleHeaders]
+		self.list = helperSizer.addLabeledControl(_("Headers:"), wx.ListBox, choices=choices)
+		self.list.SetSelection(0)
+		self.headerList = visibleHeaders
+		actions = ButtonHelper(wx.VERTICAL)
+		leftClickAction = actions.addButton(self, label=_("Left click"))
+		leftClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "LEFT"))
+		rightClickAction = actions.addButton(self, label=_("Right click"))
+		rightClickAction.Bind(wx.EVT_BUTTON, lambda event: self.onButtonClick(event, "RIGHT"))
+		helperSizer.addItem(actions)
+		mainSizer = wx.BoxSizer(wx.VERTICAL)
+		mainSizer.Add(helperSizer.sizer, border=10, flag=wx.ALL)
+		mainSizer.Fit(self)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onEscape)
+		self.SetSizer(mainSizer)
+
+	def onButtonClick(self, event, mouseButton):
+		index = self.list.GetSelection()
+		headerObj = self.headerList[index]
+		self.Close()
+		(left, top, width, height) = headerObj.location
+		winUser.setCursorPos(left + (width // 2), top + (height // 2))
+		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}DOWN".format(mouseButton)), 0, 0, None, None)
+		winUser.mouse_event(getattr(winUser, "MOUSEEVENTF_{}UP".format(mouseButton)), 0, 0, None, None)
+		ui.message(_("%s header clicked") % headerObj.name)
+		self.Destroy()
+
+	def onEscape(self, event):
+		if event.GetKeyCode() == wx.WXK_ESCAPE:
+			self.Destroy()
+		else:
+			event.Skip()
+
+	@classmethod
+	def Run(cls, title, headerList):
+		gui.mainFrame.prePopup()
+		d = cls(title, headerList)
+		if d:
+			d.Show()
+		gui.mainFrame.postPopup()

--- a/addon/globalPlugins/columnsReview/msg.py
+++ b/addon/globalPlugins/columnsReview/msg.py
@@ -1,7 +1,0 @@
-# -*- coding: UTF-8 -*-
-#A simple module to bypass the addon translation system,
-#so it can take advantage from the NVDA translations directly.
-import ui
-
-def message(message):
-	return _(message)

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ See below for more details about supported list.
 
 Default keys associated with numbers are NVDA and control, but you can customize them from add-on settings. See settings also for numpad/keyboard mode and layout.
 
-* NVDA+control+digits from 1 to 0 (keyboard mode) or from 1 to 9 (numpad mode): pressed once, read the chosen column, pressed twice, copy it;
+* NVDA+control+digits from 1 to 0 (keyboard mode) or from 1 to 9 (numpad mode): By default when pressed once, read the chosen column, pressed twice, copy it;
+If you want to customize what happens when this command is pressed please take a look at the section about customizing in settins dialog.
 * NVDA+control+numpadMinus (numpad mode): read or copy the 10th, 20th, etc column;
 * NVDA+control+- (default, EN-US layout, keyboard mode): in a list with 10+ columns, let you to change interval and read columns from 11 to 20, from 21 to 30, and so on; see settings to change last char according to your layout;
 * NVDA+control+numpadPlus (numpad mode): exactly as previous command;
@@ -22,6 +23,17 @@ Default keys associated with numbers are NVDA and control, but you can customize
 * NVDA+shift+f3: find previous occurrence;
 * NVDA+control+enter (numpadEnter in numpad mode): open column headers manager;
 * Arrows (in empty list): repeat "0 elements" message.
+
+
+## Cusotmize action performed on columns ##
+By default when pressing gesture to interact with a given column first press read its content and second copies it to the Windows clipboard.
+You can, however, customize this in the settings dialog to your liking.
+The following operations are possible:
+
+* Content of the column can be read its header is announced if the corresponding checkbox is checked.
+* Column content can be copied  along with its header if the corresponding checkbox is checked
+* Column content can be spelled out.
+* Column content can be shown in the browseable message header of the column is presented as the message title.
 
 ## For developers and advanced users ##
 


### PR DESCRIPTION
Hello  @ABuffEr First of all many thanks for adding me to authors after my previous PR. 
Now to the matter at hand. This pull requests adds an ability to  optionally spell or show column content in browse mode when pressing command to read columns given number of times.  It is of course configurable and by default behavior has not changed i.e. first press reads - second press copies. I've implemented it in a way which makes adding additional methods of presenting column content quite easy in the future. It also necessitated some refactoring namely:
- Scripts for reading columns is no longer abstract this has been achieved by no longer  making it responsible for retrieving column content - there is a new method for that which is obviously abstract in the base class.
- I've moved from global variables representing various values from the config to the normal NVDA's `config.conf` mechanic in the newly added parts of the code - it'll be necessary when working on #3 anyway.
- I've also moved parts of the code to separate files - while further separation is certainly possible it would require more thought as global variables are used quite extensively throughout the code making this process difficult.
