### PR TITLE
Fix case of the module containing  exceptions to make imports working

### DIFF
--- a/addon/globalPlugins/columnsReview/exceptions.py
+++ b/addon/globalPlugins/columnsReview/exceptions.py
@@ -1,8 +1,10 @@
 # Custom exceptions for the Columns Review add-on
 
+
 class noColumnAtIndex(Exception):
 	"""Raised when column at the specified index does not exist."""
 	pass
+
 
 class columnAtIndexNotVisible(Exception):
 	"""Raised when column at the requested index exists, but is not visible."""


### PR DESCRIPTION
Without this fix add-on fails to load since name of the module containing custom exceptions was "Exceptions" with a upper case e and Python is case sensitive when importing. I've also reintroduced two blank lines between exceptions classes - PEP8 prescribes to place two empty  lines between classes.