### PR TITLE
Fix recursion in CRTreeView

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -105,7 +105,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			clsList.insert(0, MozillaTable)
 			return
 		# found in RSSOwlnix, but may be in other software
-		if obj.role == ct.ROLE_TREEVIEW and obj.simplePrevious and obj.simplePrevious.windowClassName == "SysHeader32":
+		if (
+			obj.role == ct.ROLE_TREEVIEW
+			and obj.parent
+			and obj.parent.previous
+			and obj.parent.previous.windowClassName == "SysHeader32"
+		):
 			clsList.insert(0, CRTreeview)
 			return
 		if obj.role == ct.ROLE_LIST:


### PR DESCRIPTION
As reported in #12 when using simplePrevious in chooseOverlayClass results in recursion errors in Becky! Internet Mail. It happens because simplePrevious requests parent of the window which in this specific case is a dialog and getDialogText collects all children causing recursion. While I don't claim to understand fully why this is done like that using non simple properties in this case works around the problem and CRTreeView is still used for tree views in RSSOwlnix. Fixes #12 