### PR TITLE
Fix _RowsReader for NVDA 2021.1

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -436,7 +436,13 @@ class CRList(object):
 		if not text:
 			return
 		speech.cancelSpeech()
-		msgArgs = (_("Searching..."), speech.Spri.NOW,) if py3 else (_("Searching..."),)
+		# Translators: Message presented when search is in progress.
+		msgArgs = [_("Searching...")]
+		try:
+			from speech.priorities import SpeechPriority
+			msgArgs.append(SpeechPriority.NOW)
+		except ImportError:  # NVDA 2019.2.1 or earlier - no priorites in speechh.
+			pass
 		ui.message(*msgArgs)
 		if self.THREAD_SUPPORTED:
 			# Call launchFinder asynchronously, i.e. without expecting it to return

--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -441,7 +441,7 @@ class CRList(object):
 		try:
 			from speech.priorities import SpeechPriority
 			msgArgs.append(SpeechPriority.NOW)
-		except ImportError:  # NVDA 2019.2.1 or earlier - no priorites in speechh.
+		except ImportError:  # NVDA 2019.2.1 or earlier - no priorities in speech.
 			pass
 		ui.message(*msgArgs)
 		if self.THREAD_SUPPORTED:

--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -17,9 +17,7 @@
 from NVDAObjects.IAccessible import getNVDAObjectFromEvent
 from NVDAObjects.IAccessible import sysListView32
 from NVDAObjects.UIA import UIA # For UIA implementations only, chiefly 64-bit.
-import sayAllHandler
 import sys
-import weakref
 from comtypes.client import CreateObject
 from comtypes.gen.IAccessible2Lib import IAccessible2
 from globalCommands import commands
@@ -51,8 +49,7 @@ from .actions import ACTIONS, actionFromName, configuredActions, getActionIndexF
 from .commonFunc import NVDALocale, rangeFunc, findAllDescendantWindows, getScriptGestures
 from . import configSpec
 from .exceptions import columnAtIndexNotVisible, noColumnAtIndex
-from inspect import *
-#from logHandler import log
+from . import utils
 
 # useful to simulate profile switch handling
 nvdaVersion = '.'.join([str(version_year), str(version_major)])
@@ -256,9 +253,8 @@ class CRList(object):
 		# for current selection
 		for gesture in getScriptGestures(commands.script_reportCurrentSelection):
 			self.bindGesture(gesture, "reportCurrentSelection")
-		# for say all
-		# (available only after Py3 speech refactor)
-		if hasattr(sayAllHandler, "_ObjectsReader"):
+		# for say all - bind only if it is actually supported
+		if utils._RowsReader.isSupported():
 			for gesture in getScriptGestures(commands.script_sayAll):
 				self.bindGesture(gesture, "readListItems")
 
@@ -526,7 +522,7 @@ class CRList(object):
 
 	def script_readListItems(self, gesture):
 		curItem = api.getFocusObject()
-		_RowsReader.readRows(curItem)
+		utils._RowsReader.readRows(curItem)
 
 	script_readListItems.canPropagate = True
 	# Translators: documentation for script to read all list items starting from the focused one.
@@ -1150,25 +1146,6 @@ class FindDialog(cursorManager.FindDialog):
 		super(FindDialog, self).onOk(evt)
 
 
-sayAllSuperclass = getattr(sayAllHandler, "_ObjectsReader", object)
-
-
-class _RowsReader(sayAllSuperclass):
-
-	def walk(self, obj):
-		yield obj
-		nextObj = obj.next
-		while nextObj:
-			yield nextObj
-			nextObj = nextObj.next
-
-	@classmethod
-	def readRows(cls, obj):
-		reader = cls(obj)
-		sayAllHandler._activeSayAll = weakref.ref(reader)
-		reader.next()
-
-
 # for settings presentation compatibility
 if hasattr(gui.settingsDialogs, "SettingsPanel"):
 	superDialogClass = gui.settingsDialogs.SettingsPanel
@@ -1290,4 +1267,3 @@ class ColumnsReviewSettingsDialog(superDialogClass):
 			self.settingsSizer.Show(self._switchCharLabel)
 			self.settingsSizer.Show(self._switchChar)
 		self.Fit()
-

--- a/addon/globalPlugins/columnsReview/commonFunc.py
+++ b/addon/globalPlugins/columnsReview/commonFunc.py
@@ -38,23 +38,6 @@ def findAllDescendantWindows(parent, visible=None, controlID=None, className=Non
 	return results
 
 
-"""
-to avoid code copying to exclude ui.message
-This method is not used anywhere in the code - kept just for historical purposes.
-def runSilently(func, *args, **kwargs):
-	import speech
-	import config
-	configBackup = {"voice": speech.speechMode, "braille": config.conf["braille"]["messageTimeout"]}
-	speech.speechMode = speech.speechMode_off
-	config.conf["braille"]._cacheLeaf("messageTimeout", None, 0)
-	try:
-		func(*args, **kwargs)
-	finally:
-		speech.speechMode = configBackup["voice"]
-		config.conf["braille"]._cacheLeaf("messageTimeout", None, configBackup["braille"])
-"""
-
-
 # to get NVDA script gestures, regardless its user remap
 def getScriptGestures(scriptFunc):
 	from inputCore import manager

--- a/addon/globalPlugins/columnsReview/utils.py
+++ b/addon/globalPlugins/columnsReview/utils.py
@@ -1,0 +1,40 @@
+# Utility classes for the Columns Review add-on
+
+
+def getRowsReaderSuperClass():
+	"""Depending on the version of NVDA in use say all for list items is
+	either not supported at all (pre 2019.3 / speech refactor) or the base class allowing for reading objects
+	is defined in a different places."""
+	try:
+		import sayAllHandler as SAH
+	except ImportError:
+		import speech.sayAll as SAH
+	return getattr(SAH, "_ObjectsReader", object)
+
+
+class _RowsReader(getRowsReaderSuperClass()):
+
+	def walk(self, obj):
+		yield obj
+		nextObj = obj.next
+		while nextObj:
+			yield nextObj
+			nextObj = nextObj.next
+
+	@classmethod
+	def readRows(cls, obj):
+		import weakref
+		try:
+			import sayAllHandler
+			reader = cls(obj)
+			sayAllHandler._activeSayAll = weakref.ref(reader)
+		except ImportError:
+			import speech.sayAll
+			reader = cls(speech.sayAll.SayAllHandler, obj)
+			speech.sayAll.SayAllHandler._getActiveSayAll = weakref.ref(reader)
+		reader.next()
+
+	@classmethod
+	def isSupported(cls):
+		"""While relying on the MRO of the class is a bit tricky it avoids a lot of code duplication"""
+		return len(cls.__mro__) > 2  # The clas itself  and object- if MRO is longer super class exists.


### PR DESCRIPTION
https://github.com/nvaccess/nvda/pull/12251/ refactored `sayAllHandler` and moved its content to `speech.sayAll` - this broke `_RowsReader`. This PR makes `_RowsReader` ready for NVDA 2021.1. While at it I've made sure that priorities are imported from `speech.priorities` and removed `runSilently` which was not used any longer and therefore it was quite likely it would not be kept uptodate with the changes in NVDA - it can always be seen in the repository log.
