### PR TITLE
Fix compatibility wrapper for range

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -46,8 +46,8 @@ import winUser
 import wx
 from _ctypes import COMError
 from .actions import ACTIONS, actionFromName, configuredActions
-from .commonFunc import NVDALocale, rangeFunc, findAllDescendantWindows, getScriptGestures
-from .compat import CTWRAPPER
+from .commonFunc import NVDALocale, findAllDescendantWindows, getScriptGestures
+from .compat import CTWRAPPER, rangeFunc
 from . import configManager
 from . import configSpec
 from . import dialogs

--- a/addon/globalPlugins/columnsReview/actions.py
+++ b/addon/globalPlugins/columnsReview/actions.py
@@ -6,7 +6,8 @@ import config
 import speech
 import ui
 
-from .commonFunc import rangeFunc, NVDALocale
+from .commonFunc import NVDALocale
+from .compat import rangeFunc
 
 addonHandler.initTranslation()
 

--- a/addon/globalPlugins/columnsReview/commonFunc.py
+++ b/addon/globalPlugins/columnsReview/commonFunc.py
@@ -8,15 +8,6 @@ import winUser
 # to be able to take advantage of messages translated in NVDA core.
 NVDALocale = _
 
-def rangeFunc(*args, **kwargs):
-	try:
-		import six
-		return six.moves.range(*args, **kwargs)
-	except ImportError:
-		try:
-			return __builtins__["xrange"](*args, **kwargs)
-		except TypeError:
-			return range(*args, **kwargs)
 
 WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
 def findAllDescendantWindows(parent, visible=None, controlID=None, className=None):

--- a/addon/globalPlugins/columnsReview/compat.py
+++ b/addon/globalPlugins/columnsReview/compat.py
@@ -43,3 +43,15 @@ class ControlTypesCompatWrapper(object):
 
 
 CTWRAPPER = ControlTypesCompatWrapper()
+
+
+def rangeFunc(*args, **kwargs):
+	try:
+		import six
+		return six.moves.range(*args, **kwargs)
+	except ImportError:
+		try:
+			import __builtin__
+			return __builtin__.xrange(*args, **kwargs)
+		except ImportError:
+			return range(*args, **kwargs)


### PR DESCRIPTION
In PR #8 I've refactored our compatibility wrapper for `range` so that it accesses  `xrange` from `__builtins__` to avoid Linter warnings under Python 3.
Unfortunately it turns out I  haven't tested this code thoroughly enough and introduced the following mistakes:
- When trying to access `xrange` I've been using indexing operator and catching `TypeError` on assumption that `__builtins__` is a dictionary under Python 2, and module under Python 3 and hence is not subscriptable when on modern Python. While this holds when in the Python interpreter (that is how I tested back then) it does not work that way when outside main module as per [this Python documentation](https://docs.python.org/2.7/reference/executionmodel.html):
> By default, when in the __main__ module, __builtins__ is the built-in module __builtin__ (note: no ‘s’); when in any other module, __builtins__ is an alias for the dictionary of the __builtin__ module itself.

In short `__builtins__` is also a dictionary under Python 3 when outside main module.
- Further to the above accessing `__builtins__` is actively discouraged by Python developers (`__builtin__` should be used instead on Python 2).

Our wrapper is fixed to take the above points into account. I've also moved it to `compat` as that is where it belongs.
Note that this is not causing any real issues as of yet, since the only case where the current code on master would fail is for NVDA running under Python 3 without `six` module available.