### PR TITLE
Backwards compatibility for script used to report color of the current list item.

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -685,7 +685,7 @@ class CRList(object):
 	script_reportOrShowFormattingAtCaret.__doc__ = _(
 		# Translators: Description of the keyboard command,
 		# which reports foreground and background color of the current list item.
-		"reports foreground and background color of the current list item."
+		"reports foreground and background colors of the current list item."
 	)
 
 class CRList32(CRList):


### PR DESCRIPTION
`script_reportOrShowFormattingAtCaret` was introduced in NVDA 2020.3 - for older versions bind the script to gestures used for reporting formatting at the review cursor position. While at it I've also added description to the script so that it can be discovered in keyboard help.