### PR TITLE
Fix encoding error when running with Python 2

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -14,6 +14,8 @@
 # and to other users of NVDA mailing lists
 # for feedback and comments
 
+from __future__ import unicode_literals
+
 from displayModel import DisplayModelTextInfo
 import textInfos
 from logHandler import log


### PR DESCRIPTION
### Link to issue
Fixes #31

### Issue
With NVDA 2019.2.1, when entering an empty folder, I get the following error:
```
ERROR - eventHandler.executeEvent (21:40:12.545):
error executing event: gainFocus on <NVDAObjects.Dynamic_CRList64UIAWindowNVDAObject object at 0x05517650> with extra args of {}
Traceback (most recent call last):
  File "eventHandler.pyo", line 155, in executeEvent
  File "eventHandler.pyo", line 92, in __init__
  File "eventHandler.pyo", line 100, in next
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\columnsReview\globalPlugins\columnsReview\__init__.py", line 177, in event_gainFocus
  File "eventHandler.pyo", line 100, in next
  File "appModules\explorer.pyo", line 334, in event_gainFocus
  File "eventHandler.pyo", line 100, in next
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\columnsReview\globalPlugins\columnsReview\__init__.py", line 664, in event_gainFocus
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\columnsReview\globalPlugins\columnsReview\__init__.py", line 653, in reportEmpty
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2: ordinal not in range(128)
```

### Cause
The failing instruction is:
`region = braille.TextRegion(" {0}".format(text))`

In my case, `text` is the French translation of "0 items", that is "0 éléments". Since it contains non-ASCII character, we are trying to format a Python 2 str string with a Python 2 unicode string, hence the error.

### Solution

Make all string literals unicode strings.
