### PR TITLE
Restrict compatibility to NVDA 2019.3 onwards

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -194,20 +194,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		reportFunc(*message)
 
 	def createMenu(self):
-		# Dialog or the panel.
-		if hasattr(gui.settingsDialogs, "SettingsPanel"):
-			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(
-				dialogs.ColumnsReviewSettingsDialog
-			)
-		else:
-			self.prefsMenu = gui.mainFrame.sysTrayIcon.menu.GetMenuItems()[0].GetSubMenu()
-			# Translators: menu item in preferences
-			self.ColumnsReviewItem = self.prefsMenu.Append(wx.ID_ANY, _("Columns Review Settings..."), "")
-			gui.mainFrame.sysTrayIcon.Bind(
-				wx.EVT_MENU,
-				lambda e: gui.mainFrame._popupSettingsDialog(dialogs.ColumnsReviewSettingsDialog),
-				self.ColumnsReviewItem
-			)
+		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(
+			dialogs.ColumnsReviewSettingsDialog
+		)
 
 	def terminate(self):
 		for extPointName in PROFILE_SWITCHED_NOTIFIERS:
@@ -215,15 +204,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				getattr(config, extPointName).unregister(self.handleConfigProfileSwitch)
 			except AttributeError:
 				continue
-		if hasattr(gui.settingsDialogs, "SettingsPanel"):
-			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(
-				dialogs.ColumnsReviewSettingsDialog
-			)
-		else:
-			try:
-				self.prefsMenu.RemoveItem(self.ColumnsReviewItem)
-			except wx.PyDeadObjectError:
-				pass
+		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(
+			dialogs.ColumnsReviewSettingsDialog
+		)
 		# release COM object
 		if CRList64.shell:
 			CRList64.shell.Release()

--- a/addon/globalPlugins/columnsReview/dialogs.py
+++ b/addon/globalPlugins/columnsReview/dialogs.py
@@ -117,17 +117,12 @@ class configureActionPanel(wx.Panel):
 			self.copyHeader.Disable()
 
 
-class ColumnsReviewSettingsDialog(getattr(gui.settingsDialogs, "SettingsPanel", gui.SettingsDialog)):
-	"""Class to define settings dialog."""
+class ColumnsReviewSettingsDialog(gui.settingsDialogs.SettingsPanel):
+	"""Class to define settings panel."""
 
-	if hasattr(gui.settingsDialogs, "SettingsPanel"):
-		# Translators: title of settings dialog
-		title = _("Columns Review")
-	else:
-		# Translators: title of settings dialog
-		title = _("Columns Review Settings")
+	# Translators: title of settings panel
+	title = _("Columns Review")
 
-	# common to dialog and panel
 	def makeSettings(self, settingsSizer):
 		self.copyCheckboxEnabled = self.readCheckboxEnabled = self.hideNextPanels = False
 		self.panels = []
@@ -229,14 +224,6 @@ class ColumnsReviewSettingsDialog(getattr(gui.settingsDialogs, "SettingsPanel", 
 		if self._announceListBoundsWith.GetSelection() != 1:
 			settingsSizer.Hide(self._beepSizer) #self._beepValues)
 
-	# for dialog only
-	def postInit(self):
-		for panel in self.panels:
-			if panel.IsEnabled():
-				panel.chooseActionCombo.SetFocus()
-				break
-
-	# shared between onOk and onSave
 	def saveConfig(self):
 		# Update Configuration
 		addonConf = config.conf["columnsReview"]
@@ -270,12 +257,6 @@ class ColumnsReviewSettingsDialog(getattr(gui.settingsDialogs, "SettingsPanel", 
 				addonConf["beep"]["bottomBeep"] = bottomBeep
 				addonConf["beep"]["beepLen"] = beepLen
 
-	# for dialog only
-	def onOk(self, evt):
-		self.saveConfig()
-		super(ColumnsReviewSettingsDialog, self).onOk(evt)
-
-	# for panel only
 	def onSave(self):
 		self.saveConfig()
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -35,7 +35,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "0.0.0",
+	"addon_minimumNVDAVersion": "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2023.2",
 	# Add-on update channel (default is None, denoting stable releases,

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 * Author: Alberto Buffolino, Łukasz Golonka, other contributors
 * Download [stable version][stable]
 * Download [development version][dev]
-* NVDA compatibility: 2017.3 and beyond
+* NVDA compatibility: 2019.3 and beyond
 
 Columns Review is an add-on to enhance NVDA experience with lists.
 


### PR DESCRIPTION
### Issue
Currently the add-on claims to be compatible with NVDA 2017.3 onwards.
However, it is not compatible with Python 2 anymore, at least since the `blockUntilConditionMet.py` file from NV Access has been included since this file contain annotations.
I have not checked if there are other incompatibilities (Python or NVDA).

### Solution
My proposal is to restrict the add-on's compatibility to NVDA 2019.3 onwards. Indeed, 2019.3 is now quite old and drop Python 2 support may be welcome when we are about to switch to Python 3.11. Users of NVDA 2017.3-2019.2.1 will still be able to use the last compatible version of the add-on.

### Changes done
* Changed min version in `buildVars.py`
* Cleaned up all the code dealing with double support of Dialog/Panel in the GUI since NVDA 2019.3 and more recent versions only use panels in the settings dialog.

### Changes not done
I have not modernized other parts of the code, e.g. Python 3 `super()` syntax.

Moreover, I have not introduced `@script` decorator. I may add it if you want for `description` and `canPropagate` keywords. But given the specificity of how gestures are defined in this add-on, they would not be managed in the `@script` decorator. Let me know if you wish me to convert to `@script` decorator.

### Decision
If you do not wish to restrict compatibility, feel free to fix the compatibility issues on your side and close this PR.


