### PR TITLE
Import version constants from buildVersion for NVDA 2026.1 compatibility

### DIFF
--- a/addon/globalPlugins/columnsReview/compat.py
+++ b/addon/globalPlugins/columnsReview/compat.py
@@ -2,7 +2,7 @@
 # Provides various stuff used to preserve compatibility with older releases of NVDA.
 
 import controlTypes
-from versionInfo import *
+from buildVersion import version_year, version_major, version_minor
 
 currentVersion = (version_year, version_major, version_minor)
 


### PR DESCRIPTION
### Summary of the issue:

As of nvaccess/nvda#18682, the versionInfo module no longer imports version\_year, version\_major and version\_minor from BuildVersion. As a result, the columns review add-on fails to load on current NVDA alpha snapshots.

### Description of development approach:

This PR modifies compat.py to import the version constants directly from buildVersion. It also replaces the wildcard import with explicit variable imports, following PEP 8 recommendations and addressing a related linter warning. I did not modify buildVars.py to declare compatibility with NVDA 2026.1, as further API breaking changes may occur before the final release. Users can override compatibility if they wish to test this with development snapshots.

### Testing strategy:

I tested the add-on under NVDA 2025.3 and the latest alpha snapshot, verifying all functionality and confirming expected behavior in both environments

### Known issues with this pull request:

None
