### PR TITLE
Use buildVersion for NVDA version compatibility

### DIFF
--- a/addon/globalPlugins/columnsReview/compat.py
+++ b/addon/globalPlugins/columnsReview/compat.py
@@ -2,7 +2,11 @@
 # Provides various stuff used to preserve compatibility with older releases of NVDA.
 
 import controlTypes
-from versionInfo import *
+
+try:
+	from buildVersion import version_year, version_major, version_minor
+except ImportError:
+	from versionInfo import version_year, version_major, version_minor
 
 currentVersion = (version_year, version_major, version_minor)
 


### PR DESCRIPTION
## Summary
- Read NVDA version fields from buildVersion when available
- Keep a versionInfo fallback for older NVDA releases
- Prevent startup failures on NVDA 2026.1+ where versionInfo no longer exposes version_year/version_major/version_minor

## Verification
- python -m ruff check addon/globalPlugins/columnsReview/compat.py