### PR TITLE
Guard getFixedNum against a None simpleFirstChild

### DIFF
--- a/addon/globalPlugins/columnsReview/__init__.py
+++ b/addon/globalPlugins/columnsReview/__init__.py
@@ -790,6 +790,14 @@ class CRList32(CRList):
 	def getFixedNum(self, num):
 		curItem = api.getFocusObject()
 		child = curItem.simpleFirstChild
+		# Some list implementations report childCount > 0 but expose no simple
+		# first child object (seen with wxWidgets wxListCtrl on recent wxWidgets
+		# builds). Without a first column we can't compute an invisible-column
+		# offset, so fall back to treating the pressed number as the 1-based
+		# column index instead of crashing on child.columnNumber (issue: bare
+		# Alt/NVDA+Ctrl+n raised "'NoneType' object has no attribute 'columnNumber'").
+		if child is None or child.columnNumber is None:
+			return num
 		startNum = child.columnNumber-1
 		if num == 1:
 			return startNum+1


### PR DESCRIPTION
### Problem

`script_readColumn` (NVDA+Ctrl+`<n>`) crashes on some list controls with:

```
File ".../columnsReview/__init__.py", line 793, in getFixedNum
    startNum = child.columnNumber-1
AttributeError: 'NoneType' object has no attribute 'columnNumber'
```

`getFixedNum` reads `curItem.simpleFirstChild.columnNumber` to work out the invisible-column offset, but `simpleFirstChild` can be `None` even when `childCount > 0`.

### Reproduction

Reproducible on a `wxWidgets` `wxListCtrl` (report view) on recent wxWidgets 3.2.x builds (via wxPython): NVDA reports the focused list item has columns (`childCount > 0`) but exposes no simple first child, so **every row** of the list fails with the error above. (Originally reported against a wxPython app, NVDA 2026.2beta.)

### Fix

When there is no usable first child, fall back to treating the pressed number as the 1-based column index instead of raising. The add-on then degrades gracefully to a normal column read (or the existing "no more visible columns" path) rather than an error dialog. No behavior change for lists that already expose a first child.